### PR TITLE
Update MessageModificationServiceImpl.java

### DIFF
--- a/src/org/nightcode/milter/MessageModificationServiceImpl.java
+++ b/src/org/nightcode/milter/MessageModificationServiceImpl.java
@@ -79,9 +79,7 @@ class MessageModificationServiceImpl implements MessageModificationService {
           .build();
       context.sendPacket(packet);
       offset += length;
-      if (offset + length < body.length) {
-        length = body.length - offset;
-      }
+      length = body.length - offset;
     }
   }
 


### PR DESCRIPTION
BugFix: MessageModificationServiceImpl.replaceBody do not calculate the right size, if a body size is between 65536 and 131070.

The calculated length must always be lessened by the actual offset.